### PR TITLE
Add private CD list with full discography

### DIFF
--- a/cd-list.html
+++ b/cd-list.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <title>Lista płyt CD</title>
+    <meta name="robots" content="noindex">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+<div class="container">
+    <h1 class="mb-3">Lista płyt CD</h1>
+    <p>Ta strona zawiera listę albumów, które chciałbym mieć. Nie jest nigdzie linkowana, więc proszę zachować adres w zakładkach.</p>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>Lp.</th>
+            <th>Zespół</th>
+            <th>Album</th>
+            <th>Posiadam?</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>1</td>
+            <td>Perfect</td>
+            <td>Perfect</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td>Perfect</td>
+            <td>UNU</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Perfect</td>
+            <td>Jestem</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>4</td>
+            <td>Perfect</td>
+            <td>Geny</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>5</td>
+            <td>Perfect</td>
+            <td>Śmigło</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>6</td>
+            <td>Perfect</td>
+            <td>Schody</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>7</td>
+            <td>Perfect</td>
+            <td>XXX</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>8</td>
+            <td>Perfect</td>
+            <td>DaDaDam</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>9</td>
+            <td>Perfect</td>
+            <td>Muzyka</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>10</td>
+            <td>Budka Suflera</td>
+            <td>Cień wielkiej góry</td>
+            <td>Tak</td>
+        </tr>
+        <tr>
+            <td>11</td>
+            <td>Budka Suflera</td>
+            <td>Przechodniem byłem między wami</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>12</td>
+            <td>Budka Suflera</td>
+            <td>Na brzegu światła</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>13</td>
+            <td>Budka Suflera</td>
+            <td>Ona przyszła prosto z chmur</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>14</td>
+            <td>Budka Suflera</td>
+            <td>Za ostatni grosz</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>15</td>
+            <td>Budka Suflera</td>
+            <td>Czas czekania, czas olśnienia</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>16</td>
+            <td>Budka Suflera</td>
+            <td>Giganci tańczą</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>17</td>
+            <td>Budka Suflera</td>
+            <td>Ratujmy co się da</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>18</td>
+            <td>Budka Suflera</td>
+            <td>Cisza</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>19</td>
+            <td>Budka Suflera</td>
+            <td>Noc</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>20</td>
+            <td>Budka Suflera</td>
+            <td>Nic nie boli, tak jak życie</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>21</td>
+            <td>Budka Suflera</td>
+            <td>Bal wszystkich świętych</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>22</td>
+            <td>Budka Suflera</td>
+            <td>Mokre oczy</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>23</td>
+            <td>Budka Suflera</td>
+            <td>Jest</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>24</td>
+            <td>Budka Suflera</td>
+            <td>Zawsze czegoś brak</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>25</td>
+            <td>Budka Suflera</td>
+            <td>10 lat samotności</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>26</td>
+            <td>Budka Suflera</td>
+            <td>Skaza</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>27</td>
+            <td>AC/DC</td>
+            <td>High Voltage (Australasia)</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>28</td>
+            <td>AC/DC</td>
+            <td>T.N.T.</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>29</td>
+            <td>AC/DC</td>
+            <td>High Voltage</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>30</td>
+            <td>AC/DC</td>
+            <td>Dirty Deeds Done Dirt Cheap</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>31</td>
+            <td>AC/DC</td>
+            <td>Let There Be Rock</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>32</td>
+            <td>AC/DC</td>
+            <td>Powerage</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>33</td>
+            <td>AC/DC</td>
+            <td>Highway to Hell</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>34</td>
+            <td>AC/DC</td>
+            <td>Back in Black</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>35</td>
+            <td>AC/DC</td>
+            <td>For Those About to Rock We Salute You</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>36</td>
+            <td>AC/DC</td>
+            <td>Flick of the Switch</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>37</td>
+            <td>AC/DC</td>
+            <td>Fly on the Wall</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>38</td>
+            <td>AC/DC</td>
+            <td>Blow Up Your Video</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>39</td>
+            <td>AC/DC</td>
+            <td>The Razors Edge</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>40</td>
+            <td>AC/DC</td>
+            <td>Ballbreaker</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>41</td>
+            <td>AC/DC</td>
+            <td>Stiff Upper Lip</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>42</td>
+            <td>AC/DC</td>
+            <td>Black Ice</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>43</td>
+            <td>AC/DC</td>
+            <td>Rock or Bust</td>
+            <td>Nie</td>
+        </tr>
+        <tr>
+            <td>44</td>
+            <td>AC/DC</td>
+            <td>Power Up</td>
+            <td>Nie</td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jq-3.3.1/jszip-2.5.0/dt-1.10.20/b-1.6.1/b-colvis-1.6.1/b-html5-1.6.1/b-print-1.6.1/datatables.min.css"/>
+    <title>Repo List</title>
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/pdfmake.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/vfs_fonts.js"></script>


### PR DESCRIPTION
## Summary
- restyled `cd-list.html` with Bootstrap and translated page text to Polish
- expanded table to include complete discography of Perfect, Budka Suflera, and AC/DC
- added a missing `<title>` to `index.html` so html5validator passes

## Testing
- `~/.local/bin/html5validator --root .`

------
https://chatgpt.com/codex/tasks/task_e_68458aa5cd5c832f9100e0dc8336ad40