### PR TITLE
Add album management controls

### DIFF
--- a/cd-list.html
+++ b/cd-list.html
@@ -48,6 +48,9 @@ function renderTable() {
         <td>
           <button class="btn btn-sm btn-secondary move-up" data-index="${idx}">&#8593;</button>
           <button class="btn btn-sm btn-secondary move-down" data-index="${idx}">&#8595;</button>
+          <button class="btn btn-sm btn-secondary move-top" data-index="${idx}">&#8657;</button>
+          <button class="btn btn-sm btn-secondary move-bottom" data-index="${idx}">&#8659;</button>
+          <button class="btn btn-sm btn-danger delete-item" data-index="${idx}">&#10060;</button>
           <button class="btn btn-sm btn-secondary upload-thumb" data-index="${idx}">Thumb</button>
           <input type="file" accept="image/*" class="thumb-input d-none" data-index="${idx}">
         </td>
@@ -93,6 +96,17 @@ window.addEventListener('DOMContentLoaded', () => {
       } else if (e.target.classList.contains('move-down') && index < albums.length - 1) {
         [albums[index + 1], albums[index]] = [albums[index], albums[index + 1]];
         renderTable();
+      } else if (e.target.classList.contains('move-top')) {
+        const item = albums.splice(index, 1)[0];
+        albums.unshift(item);
+        renderTable();
+      } else if (e.target.classList.contains('move-bottom')) {
+        const item = albums.splice(index, 1)[0];
+        albums.push(item);
+        renderTable();
+      } else if (e.target.classList.contains('delete-item')) {
+        albums.splice(index, 1);
+        renderTable();
       } else if (e.target.classList.contains('upload-thumb')) {
         e.target.parentElement.querySelector('.thumb-input').click();
       }
@@ -126,15 +140,36 @@ window.addEventListener('DOMContentLoaded', () => {
     });
 
     const container = document.querySelector('.container');
+    const table = container.querySelector('table');
+
+    const btnGroup = document.createElement('div');
+    btnGroup.className = 'mb-3';
+
+    const addBtn = document.createElement('button');
+    addBtn.className = 'btn btn-success me-2';
+    addBtn.textContent = 'Add Album';
+    btnGroup.appendChild(addBtn);
+
     const exportBtn = document.createElement('button');
-    exportBtn.className = 'btn btn-primary mt-3';
+    exportBtn.className = 'btn btn-primary';
     exportBtn.textContent = 'Export JSON';
-    container.appendChild(exportBtn);
+    btnGroup.appendChild(exportBtn);
+
+    container.insertBefore(btnGroup, table);
 
     const textarea = document.createElement('textarea');
     textarea.className = 'form-control mt-2';
     textarea.style.display = 'none';
     container.appendChild(textarea);
+
+    addBtn.addEventListener('click', () => {
+      const band = prompt('Zespół:');
+      if (band === null || band.trim() === '') return;
+      const albumName = prompt('Album:');
+      if (albumName === null || albumName.trim() === '') return;
+      albums.push({ rank: albums.length + 1, band: band.trim(), album: albumName.trim(), owned: false, thumb: '' });
+      renderTable();
+    });
 
     exportBtn.addEventListener('click', () => {
       textarea.style.display = 'block';


### PR DESCRIPTION
## Summary
- allow editing album list with add/delete/top/bottom buttons
- move add and export controls above the table

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68474cd944bc832fa40b84f70b41aa74