### PR TITLE
Add clipboard export with modal

### DIFF
--- a/cd-list.html
+++ b/cd-list.html
@@ -5,6 +5,7 @@
     <title>Lista płyt CD</title>
     <meta name="robots" content="noindex">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </head>
 <body class="p-4">
 <div class="container">
@@ -21,6 +22,19 @@
         </thead>
         <tbody id="album-table-body"></tbody>
     </table>
+</div>
+<div class="modal fade" id="copyModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Skopiowano</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        Dane zostały skopiowane do schowka.
+      </div>
+    </div>
+  </div>
 </div>
 <script src="albums.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
@@ -157,10 +171,6 @@ window.addEventListener('DOMContentLoaded', () => {
 
     container.insertBefore(btnGroup, table);
 
-    const textarea = document.createElement('textarea');
-    textarea.className = 'form-control mt-2';
-    textarea.style.display = 'none';
-    container.appendChild(textarea);
 
     addBtn.addEventListener('click', () => {
       const band = prompt('Zespół:');
@@ -172,8 +182,11 @@ window.addEventListener('DOMContentLoaded', () => {
     });
 
     exportBtn.addEventListener('click', () => {
-      textarea.style.display = 'block';
-      textarea.value = JSON.stringify(albums, null, 2);
+      const jsContent = 'const albums = ' + JSON.stringify(albums, null, 2) + ';';
+      navigator.clipboard.writeText(jsContent).then(() => {
+        const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('copyModal'));
+        modal.show();
+      });
     });
   }
 });


### PR DESCRIPTION
## Summary
- show modal when albums JSON is copied
- load Bootstrap JS for modal support
- copy export data so it can be pasted over `albums.js`

## Testing
- `node -e "require('fs').readFile('cd-list.html', 'utf8', (e,d)=>{if(e)throw e;console.log('length', d.length)})"`


------
https://chatgpt.com/codex/tasks/task_e_684d5c7c22ec832fb5e0be9c285fbf5b