### PR TITLE
Improve album cover suggestions

### DIFF
--- a/cd-list.html
+++ b/cd-list.html
@@ -227,9 +227,9 @@ window.addEventListener('DOMContentLoaded', () => {
     thumbModalBody.innerHTML = 'Loading...';
     currentThumbIndex = idx;
     thumbModal.show();
-    const query = encodeURIComponent(album.band + ' ' + album.album + ' album cover');
+    const query = encodeURIComponent(album.band + ' ' + album.album + ' album cover art');
     Promise.all([
-      fetch(`https://itunes.apple.com/search?term=${query}&entity=album&limit=5`).then(r => r.json()),
+      fetch(`https://itunes.apple.com/search?term=${query}&entity=album&limit=8`).then(r => r.json()),
       fetch(`https://r.jina.ai/https://www.google.com/search?tbm=isch&q=${query}`).then(r => r.text())
     ])
       .then(([itunesRes, googleHtml]) => {
@@ -237,7 +237,10 @@ window.addEventListener('DOMContentLoaded', () => {
         let found = false;
 
         if (itunesRes.results.length > 0) {
-          itunesRes.results.forEach(r => {
+            const headerItunes = document.createElement('h6');
+            headerItunes.textContent = 'iTunes';
+            thumbModalBody.appendChild(headerItunes);
+          itunesRes.results.slice(0,4).forEach(r => {
             const url = r.artworkUrl100.replace('100x100bb', '200x200bb');
             const img = document.createElement('img');
             img.src = url;
@@ -251,19 +254,24 @@ window.addEventListener('DOMContentLoaded', () => {
 
         const parser = new DOMParser();
         const doc = parser.parseFromString(googleHtml, 'text/html');
-        Array.from(doc.querySelectorAll('img'))
+        const googleImgs = Array.from(doc.querySelectorAll('img'))
           .map(i => i.src)
           .filter(src => src && src.startsWith('http'))
-          .slice(0, 5)
-          .forEach(url => {
+          .slice(0, 4);
+        if (googleImgs.length > 0) {
+          const headerGoogle = document.createElement('h6');
+          headerGoogle.textContent = 'Google Images';
+          thumbModalBody.appendChild(headerGoogle);
+          googleImgs.forEach(url => {
             const img = document.createElement('img');
             img.src = url;
             img.dataset.url = url;
             img.className = 'img-thumbnail m-1 thumb-option';
             img.style.cursor = 'pointer';
             thumbModalBody.appendChild(img);
-            found = true;
           });
+          found = true;
+        }
 
         if (!found) {
           thumbModalBody.textContent = 'No thumbnails found.';


### PR DESCRIPTION
## Summary
- tweak Google search query to include `album cover art`
- show suggestions separately for iTunes and Google Images
- limit suggestions to four per source

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684e9f282b58832fa928c1ef8ffe5ffb