### PR TITLE
Fix cd-list thumbnail lookup

### DIFF
--- a/cd-list.html
+++ b/cd-list.html
@@ -227,10 +227,11 @@ window.addEventListener('DOMContentLoaded', () => {
     thumbModalBody.innerHTML = 'Loading...';
     currentThumbIndex = idx;
     thumbModal.show();
-    const query = encodeURIComponent(album.band + ' ' + album.album + ' album cover art');
+    const searchTerms = encodeURIComponent(album.band + ' ' + album.album);
+    const query = `${searchTerms}+album+cover+art`;
     Promise.all([
-      fetch(`https://itunes.apple.com/search?term=${query}&entity=album&limit=8`).then(r => r.json()),
-      fetch(`https://r.jina.ai/https://www.google.com/search?tbm=isch&q=${query}`).then(r => r.text())
+      fetch(`https://itunes.apple.com/search?term=${searchTerms}&entity=album&limit=8`).then(r => r.json()).catch(() => ({results: []})),
+      fetch(`https://r.jina.ai/https://www.google.com/search?tbm=isch&q=${query}`).then(r => r.text()).catch(() => '')
     ])
       .then(([itunesRes, googleHtml]) => {
         thumbModalBody.innerHTML = '';


### PR DESCRIPTION
## Summary
- improve search queries for thumbnails from iTunes and Google
- add error handling for thumbnail searches

## Testing
- `curl -s "https://itunes.apple.com/search?term=Perfect%20Perfect&entity=album&limit=8" | head -n 40`

------
https://chatgpt.com/codex/tasks/task_e_684ea4eb4114832f96011ab69cb807ba