### PR TITLE
Fix Google images suggestions

### DIFF
--- a/cd-list.html
+++ b/cd-list.html
@@ -231,7 +231,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const query = `${searchTerms}+album+cover+art`;
     Promise.all([
       fetch(`https://itunes.apple.com/search?term=${searchTerms}&entity=album&limit=8`).then(r => r.json()).catch(() => ({results: []})),
-      fetch(`https://r.jina.ai/https://www.google.com/search?tbm=isch&q=${query}`).then(r => r.text()).catch(() => '')
+      fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent('https://www.google.com/search?tbm=isch&q=' + query)}`).then(r => r.text()).catch(() => '') // Use allorigins to bypass CORS
     ])
       .then(([itunesRes, googleHtml]) => {
         thumbModalBody.innerHTML = '';


### PR DESCRIPTION
## Summary
- use allorigins proxy to fetch Google Images HTML
- document why allorigins is used for CORS

## Testing
- `curl -s 'https://api.allorigins.win/raw?url=https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3Dtest%26tbm%3Disch' | grep -Eo '<img[^>]+>' | head -n 3`

------
https://chatgpt.com/codex/tasks/task_e_684ea84eba90832fbfa5d26784e7736e