### PR TITLE
Fix iTunes thumbnail loading

### DIFF
--- a/cd-list.html
+++ b/cd-list.html
@@ -222,6 +222,18 @@ window.addEventListener('DOMContentLoaded', () => {
   thumbModalBody = document.getElementById('thumbModalBody');
   thumbModalTitle = document.getElementById('thumbModalTitle');
 
+  function fetchItunesAlbums(searchTerms) {
+    const url = `https://itunes.apple.com/search?term=${searchTerms}&entity=album&limit=8`;
+    const proxy = `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
+    return fetch(proxy).then(r => r.json()).catch(() => ({results: []}));
+  }
+
+  function fetchGoogleImages(query) {
+    const url = `https://www.google.com/search?tbm=isch&q=${query}`;
+    const proxy = `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
+    return fetch(proxy).then(r => r.text()).catch(() => '');
+  }
+
   function showThumbModal(idx) {
     const album = albums[idx];
     thumbModalTitle.textContent = `Select Thumbnail - ${album.band} - ${album.album}`;
@@ -234,8 +246,8 @@ window.addEventListener('DOMContentLoaded', () => {
       const searchTerms = encodeURIComponent(search.trim());
       const query = `${searchTerms}+album+cover+art`;
     Promise.all([
-      fetch(`https://itunes.apple.com/search?term=${searchTerms}&entity=album&limit=8`).then(r => r.json()).catch(() => ({results: []})),
-      fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent('https://www.google.com/search?tbm=isch&q=' + query)}`).then(r => r.text()).catch(() => '') // Use allorigins to bypass CORS
+      fetchItunesAlbums(searchTerms),
+      fetchGoogleImages(query)
     ])
       .then(([itunesRes, googleHtml]) => {
         thumbModalBody.innerHTML = '';


### PR DESCRIPTION
## Summary
- refactor thumbnail fetching logic into two helper methods
- fetch iTunes results via AllOrigins proxy to bypass CORS
- use helper methods when requesting album art

## Testing
- `curl -s "https://api.allorigins.win/raw?url=https://itunes.apple.com/search?term=Beatles&entity=album&limit=1" | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684eebe06fe8832fba24ae6099118bba