### PR TITLE
Add country field and update version

### DIFF
--- a/cd-list.html
+++ b/cd-list.html
@@ -8,7 +8,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </head>
 <body class="p-4">
-<div style="position: fixed; top: 0; left: 0; font-size: 0.8em; color: grey; opacity: 0.6; padding: 2px;">b1de974 2025-06-15</div>
+<div style="position: fixed; top: 0; left: 0; font-size: 0.8em; color: grey; opacity: 0.6; padding: 2px;">c21b08b 2025-06-15</div>
 <div class="container">
     <h1 class="mb-3">Lista płyt CD</h1>
     <p>Ta strona zawiera listę albumów, które chciałbym mieć. Nie jest nigdzie linkowana, więc proszę zachować adres w zakładkach.</p>
@@ -53,6 +53,10 @@
           <div class="mb-3">
             <label for="albumInput" class="form-label">Album</label>
             <input type="text" class="form-control" id="albumInput" required>
+          </div>
+          <div class="mb-3">
+            <label for="countryInput" class="form-label">Country</label>
+            <input type="text" class="form-control" id="countryInput">
           </div>
         </form>
       </div>
@@ -217,6 +221,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const addModal = bootstrap.Modal.getOrCreateInstance(addModalEl);
   const bandInput = document.getElementById('bandInput');
   const albumInput = document.getElementById('albumInput');
+  const countryInput = document.getElementById('countryInput');
   const thumbModalEl = document.getElementById('thumbModal');
   thumbModal = bootstrap.Modal.getOrCreateInstance(thumbModalEl);
   thumbModalBody = document.getElementById('thumbModalBody');
@@ -333,6 +338,7 @@ window.addEventListener('DOMContentLoaded', () => {
     addBtn.addEventListener('click', () => {
       bandInput.value = '';
       albumInput.value = '';
+      countryInput.value = '';
       addModal.show();
     });
 
@@ -340,8 +346,9 @@ window.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       const band = bandInput.value.trim();
       const albumName = albumInput.value.trim();
+      const country = countryInput.value.trim();
       if (!band || !albumName) return;
-      albums.push({ rank: albums.length + 1, band, album: albumName, owned: false, thumb: '' });
+      albums.push({ rank: albums.length + 1, band, album: albumName, country, owned: false, thumb: '' });
       renderTable();
       addModal.hide();
     });


### PR DESCRIPTION
## Summary
- add Country field to CD list form
- reset and save country info in scripts
- bump version display

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f0bb8bb64832fa225f6a60232666c