### PR TITLE
Improve 'Posiadam' column styling

### DIFF
--- a/cd-list.html
+++ b/cd-list.html
@@ -5,6 +5,11 @@
     <title>Lista płyt CD</title>
     <meta name="robots" content="noindex">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+      .owned-text {
+        text-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
+      }
+    </style>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </head>
 <body class="p-4">
@@ -116,7 +121,9 @@ function renderTable() {
         </td>
       `;
     } else {
-      const ownedText = album.owned ? 'Tak' : 'Nie';
+      const ownedText = album.owned
+        ? '<span class="text-success owned-text">Tak</span>'
+        : '<span class="text-danger owned-text">Nie</span>';
       tr.innerHTML = `
         <td>${idx + 1}</td>
         <td>${album.band}</td>


### PR DESCRIPTION
## Summary
- style owned column with Bootstrap colors
- add text shadow for readability

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6866488dfb58832fbee61de954355804